### PR TITLE
Make API Key secret

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,6 @@
 plugins:
   discourse_mattermost_api_key:
     default: ""
+    secret: true
   discourse_mattermost_server:
     default: ""


### PR DESCRIPTION
Don't display API Key by default, require logged click