### PR TITLE
FEATURE: Set mattermost status based on vacation status

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,3 +2,8 @@ en:
   site_settings:
     discourse_mattermost_api_key: "Secret API key to access Mattermost APIs."
     discourse_mattermost_server: "URL of the Mattermost server. Make sure to include http(s)://"
+    discourse_mattermost_suffix_usernames: "Add -v to mattermost users on vacation"
+    discourse_mattermost_set_status: "Set status emoji/text for mattermost users on vacation"
+    discourse_mattermost_holiday_status_emoji: "Emoji to use for mattermost vacation status"
+    discourse_mattermost_holiday_status_text: "Text for mattermost vacation status"
+    discourse_mattermost_holiday_status_exclusive: "Remove all non-vacation mattermost statuses"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,3 +4,8 @@ plugins:
     secret: true
   discourse_mattermost_server:
     default: ""
+  discourse_mattermost_suffix_usernames: true
+  discourse_mattermost_set_status: true
+  discourse_mattermost_holiday_status_emoji: "palm_tree"
+  discourse_mattermost_holiday_status_text: "On vacation"
+  discourse_mattermost_holiday_status_exclusive: false

--- a/jobs/scheduled/update_mattermost_usernames.rb
+++ b/jobs/scheduled/update_mattermost_usernames.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Jobs
-  class UpdateMattermostUsernames < Jobs::Scheduled
+  class UpdateMattermostUsernames < ::Jobs::Scheduled
     every 10.minutes
 
     def execute(args)
@@ -9,41 +11,61 @@ module Jobs
 
       return if api_key.blank? || server.blank?
 
-      # Fetch all mattermost users
-      response = Excon.get("#{server}/api/v4/users", headers: {
+      headers = {
         "Authorization": "Bearer #{api_key}"
-      })
+      }
+
+      # Fetch all mattermost users
+      response = Excon.get("#{server}/api/v4/users", headers: headers)
       mattermost_users = JSON.parse(response.body, symbolize_names: true)
 
       # Loop over mattermost users
       mattermost_users.each do |user|
-        mattermost_username = user[:username]
-        marked_on_holiday = !!mattermost_username.chomp!("-v")
-
         discourse_user = User.find_by_email(user[:email])
         next unless discourse_user
         discourse_username = discourse_user.username
 
         on_holiday = users_on_holiday.include?(discourse_username)
 
-        update_username = false
-        if on_holiday && !marked_on_holiday
-          update_username = "#{mattermost_username}-v"
-        elsif !on_holiday && marked_on_holiday
-          update_username = mattermost_username
+        if SiteSetting.discourse_mattermost_suffix_usernames
+          mattermost_username = user[:username]
+          username_on_holiday = !!mattermost_username.chomp!("-v")
+
+          update_username = false
+          if on_holiday && !username_on_holiday
+            update_username = "#{mattermost_username}-v"
+          elsif !on_holiday && username_on_holiday
+            update_username = mattermost_username
+          end
+
+          if update_username
+            # puts "Update #{mattermost_username} to #{update_username}"
+            Excon.put("#{server}/api/v4/users/#{user[:id]}/patch",
+              headers: headers,
+              body: { username: update_username }.to_json
+            )
+          end
         end
 
-        if update_username
-          # puts "Update #{mattermost_username} to #{update_username}"
-          Excon.put("#{server}/api/v4/users/#{user[:id]}/patch", headers: {
-            "Authorization": "Bearer #{api_key}"
-          }, body: {
-            username: update_username
-          }.to_json)
-        end
+        if SiteSetting.discourse_mattermost_set_status
+          status_json = user.dig(:props, :customStatus)
+          status_data = status_json.present? ? JSON.parse(status_json, symbolize_names: true) : nil
+          status_emoji = status_data&.[](:emoji)
+          status_on_holiday = status_data&.[](:emoji) == SiteSetting.discourse_mattermost_holiday_status_emoji
 
+          if on_holiday && !status_on_holiday
+            Excon.put("#{server}/api/v4/users/#{user[:id]}/status/custom",
+              headers: headers,
+              body: {
+                emoji: SiteSetting.discourse_mattermost_holiday_status_emoji,
+                text: SiteSetting.discourse_mattermost_holiday_status_text
+              }.to_json
+            )
+          elsif status_on_holiday || (SiteSetting.discourse_mattermost_holiday_status_exclusive && status_emoji)
+            Excon.delete("#{server}/api/v4/users/#{user[:id]}/status/custom", headers: headers)
+          end
+        end
       end
-
     end
 
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # name: discourse-mattermost-holidays-sync
 # about: Updated mattermost usernames with `-v` for users on holiday
 # version: 0.1

--- a/spec/integration/update_mattermost_holiday_usernames_spec.rb
+++ b/spec/integration/update_mattermost_holiday_usernames_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe "Mattermost holiday sync" do
+  def run_job
+    ::Jobs::UpdateMattermostUsernames.new.execute(nil)
+  end
+
+  it "does nothing when disabled" do
+    run_job
+  end
+
+  context "with credentials" do
+    before do
+      SiteSetting.discourse_mattermost_api_key = "abc"
+      SiteSetting.discourse_mattermost_server = "https://chat.example.com"
+      DiscourseCalendar.users_on_holiday = []
+    end
+
+    let(:discourse_user) { Fabricate(:user) }
+
+    let(:users_body_data) {
+      [
+        {
+          id: "userid",
+          username: "david",
+          email: discourse_user.email,
+          props: { customStatus: "" }
+        }
+      ]
+    }
+
+    let!(:users_stub) {
+      stub_request(:get, "https://chat.example.com/api/v4/users").
+        with(headers: {
+        'Authorization' => 'Bearer abc',
+        'Host' => 'chat.example.com'
+      }).
+        to_return { { status: 200, body: users_body_data.to_json, headers: {} } }
+    }
+
+    it "does nothing when no changes are required" do
+      run_job
+      expect(users_stub).to have_been_requested
+    end
+
+    it "updates username and status when required" do
+      DiscourseCalendar.users_on_holiday = [discourse_user.username]
+      username_change = stub_request(:put, "https://chat.example.com/api/v4/users/userid/patch").
+        with(body: { username: "david-v" }.to_json)
+
+      status_change = stub_request(:put, "https://chat.example.com/api/v4/users/userid/status/custom").
+        with(body: {
+          emoji: SiteSetting.discourse_mattermost_holiday_status_emoji,
+          text: SiteSetting.discourse_mattermost_holiday_status_text
+          }.to_json
+        )
+
+      run_job
+      expect(users_stub).to have_been_requested
+      expect(username_change).to have_been_requested
+      expect(status_change).to have_been_requested
+    end
+
+    it "does not attempt changes when already correct" do
+      DiscourseCalendar.users_on_holiday = [discourse_user.username]
+      users_body_data[0][:username] = "david-v"
+      users_body_data[0][:props][:customStatus] = {
+        emoji: SiteSetting.discourse_mattermost_holiday_status_emoji,
+        text: SiteSetting.discourse_mattermost_holiday_status_text
+      }.to_json
+
+      run_job
+      expect(users_stub).to have_been_requested
+    end
+
+    it "resets user when no longer on vacation" do
+      DiscourseCalendar.users_on_holiday = []
+      users_body_data[0][:username] = "david-v"
+      users_body_data[0][:props][:customStatus] = {
+        emoji: SiteSetting.discourse_mattermost_holiday_status_emoji,
+        text: SiteSetting.discourse_mattermost_holiday_status_text
+      }.to_json
+
+      username_change = stub_request(:put, "https://chat.example.com/api/v4/users/userid/patch").
+        with(body: { username: "david" }.to_json)
+
+      status_change = stub_request(:delete, "https://chat.example.com/api/v4/users/userid/status/custom")
+
+      run_job
+      expect(users_stub).to have_been_requested
+      expect(username_change).to have_been_requested
+      expect(status_change).to have_been_requested
+    end
+  end
+end


### PR DESCRIPTION
Optionally (default on) set users' mattermost status emoji/text when they are on vacation. The emoji is customizable via the site setting. If the user is not on vacation, and their status has this specific emoji, their status will be cleared.

Optionally (default off) this job can clear ALL non-discourse-managed mattermost statuses