### PR TITLE
FIX: Fetch multiple pages of mattermost users if necessary

### DIFF
--- a/jobs/scheduled/update_mattermost_usernames.rb
+++ b/jobs/scheduled/update_mattermost_usernames.rb
@@ -16,8 +16,15 @@ module Jobs
       }
 
       # Fetch all mattermost users
-      response = Excon.get("#{server}/api/v4/users", headers: headers)
-      mattermost_users = JSON.parse(response.body, symbolize_names: true)
+      mattermost_users = []
+      params = { per_page: 200, page: 0 }
+      loop do
+        response = Excon.get("#{server}/api/v4/users?#{params.to_query}", headers: headers)
+        this_page_users = JSON.parse(response.body, symbolize_names: true)
+        mattermost_users += this_page_users
+        break if this_page_users.length < params[:per_page]
+        params[:page] += 1
+      end
 
       # Loop over mattermost users
       mattermost_users.each do |user|

--- a/spec/integration/update_mattermost_holiday_usernames_spec.rb
+++ b/spec/integration/update_mattermost_holiday_usernames_spec.rb
@@ -31,7 +31,7 @@ describe "Mattermost holiday sync" do
     }
 
     let!(:users_stub) {
-      stub_request(:get, "https://chat.example.com/api/v4/users").
+      stub_request(:get, "https://chat.example.com/api/v4/users?page=0&per_page=200").
         with(headers: {
         'Authorization' => 'Bearer abc',
         'Host' => 'chat.example.com'


### PR DESCRIPTION
The default page size is 60. This commit increases the page size to 200 (the maximum), and adds logic to make multiple requests when there are more than 200 users.